### PR TITLE
Fix typo in BlobStorageExtensions comment

### DIFF
--- a/src/Open.AsyncToolkit.BlobStorage/BlobStorageExtensions.cs
+++ b/src/Open.AsyncToolkit.BlobStorage/BlobStorageExtensions.cs
@@ -120,7 +120,7 @@ public static class BlobStorageExtensions
 		if (data.IsEmpty) return;
 
 		cancellationToken.ThrowIfCancellationRequested();
-		// Write to the steam manually instead of using the modern methods.
+                // Write to the stream manually instead of using the modern methods.
 
 		// Get a handle to the underlying memory without copying
 		if (MemoryMarshal.TryGetArray(data, out ArraySegment<byte> segment))


### PR DESCRIPTION
## Summary
- fix minor typo in BlobStorageExtensions comment

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3f1727b8832b8f5266c8c117bc12